### PR TITLE
GitHub Actionsのaction参照をSHAハッシュでピン留め

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Run tests
       run: |
         npm ci

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
     - name: Package
       run: |
         npm ci


### PR DESCRIPTION
## Summary
- セキュリティ向上のため、GitHub Actionsのworkflowファイルで使用しているactionの参照をタグ指定からSHAハッシュ指定に変更
- `pinact run` を使用して自動変換を実施

## Why
タグはリポジトリオーナーによって書き換え可能なため、サプライチェーン攻撃のリスクがあります。SHAハッシュでピン留めすることで、意図しないコード変更を防ぎます。

## Test plan
- [ ] 各workflowが正常に動作すること（既存のactionバージョンと同一コミットを指しているため、動作に変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
